### PR TITLE
Fix - use github.ref for non manual runs

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: ${{ inputs.branch }}
+        ref: ${{ inputs.branch || github.ref }}
     
     - name: configure
       run: ./configure --target=aarch64-pe --prefix="$HOME/cross"
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: ${{ inputs.branch }}
+        ref: ${{ inputs.branch || github.ref }}
     
     - name: configure
       run: ./configure --enable-targets=all


### PR DESCRIPTION
In order to run CI for pull_requests and pushes we need to use github.ref as fallback option